### PR TITLE
Added RoseTree.graph_mut() to allow mutable access to underlying petgraph.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! **rose_tree** is a rose tree (aka multi-way tree) data structure library.
 //!
 //! The most prominent type is [**RoseTree**](./struct.RoseTree.html) - a wrapper around [petgraph]
@@ -115,6 +115,13 @@ impl<N, Ix = DefIndex> RoseTree<N, Ix> where Ix: IndexType {
     /// used to index into the `RoseTree`.
     pub fn graph(&self) -> &PetGraph<N, Ix> {
         &self.graph
+    }
+
+    /// Borrow a mutable reference to the `RoseTree`'s underlying `PetGraph<N, Ix>`.
+    /// All existing `NodeIndex`s may be used to index into this graph the same way they may be
+    /// used to index into the `RoseTree`.
+    pub fn graph_mut(&mut self) -> &mut PetGraph<N, Ix> {
+        &mut self.graph
     }
 
     /// Take ownership of the RoseTree and return the internal PetGraph<N, Ix>.


### PR DESCRIPTION
Would you consider adding this method so that one can obtain mutable access to the underlying `petgraph`? AFAIK, it's the only easy way\* to use the algorithms in `petgraph` to do traversal while maintaining mutable access to the underlying nodes (without consuming the RoseTree via `into_graph`). 

The context I'm using it in is a scene graph backed by `rose_tree`, so I'm mutably traversing the graph to do layout, and collision detection; But, immutably traversing it for rendering.

*The alternative being to make nodes of type `RefCell<Node>`?

```
    let mut graph = tree.graph_mut();

    let mut dfs = petgraph::Dfs::new(graph, petgraph::graph::NodeIndex::new(ROOT));
    while let Some(node_index) = dfs.next(graph) {
        let node = graph.node_weight_mut(node_index).unwrap();
       ...........
```
