### PR TITLE
Update Petgraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/mitchmindtree/rose_tree-rs"
 
 
 [dependencies]
-petgraph = "0.1.11"
+petgraph = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! **rose_tree** is a rose tree (aka multi-way tree) data structure library.
 //!
 //! The most prominent type is [**RoseTree**](./struct.RoseTree.html) - a wrapper around [petgraph]
@@ -16,10 +16,8 @@ use petgraph as pg;
 pub use petgraph::graph::NodeIndex;
 use petgraph::graph::{DefIndex, IndexType};
 
-
 /// The PetGraph to be used internally within the RoseTree for storing/managing nodes and edges.
 pub type PetGraph<N, Ix> = pg::Graph<N, (), pg::Directed, Ix>;
-
 
 /// An indexable tree data structure with a variable and unbounded number of branches per node.
 ///
@@ -56,7 +54,6 @@ pub struct RoseTree<N, Ix: IndexType = DefIndex> {
     graph: PetGraph<N, Ix>,
 }
 
-
 /// An iterator that yeilds an index to the parent of the current child before the setting the
 /// parent as the new current child. This occurs recursively until the root index is yeilded.
 pub struct ParentRecursion<'a, N: 'a, Ix: IndexType> {
@@ -87,9 +84,10 @@ pub struct WalkSiblings<Ix: IndexType> {
 /// `RoseTree`'s API ensures that it always has a "root" node and that its index is always 0.
 pub const ROOT: usize = 0;
 
-
-impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
-
+impl<N, Ix> RoseTree<N, Ix>
+where
+    Ix: IndexType,
+{
     /// Create a new `RoseTree` along with some root node.
     /// Returns both the `RoseTree` and an index into the root node in a tuple.
     pub fn new(root: N) -> (Self, NodeIndex<Ix>) {
@@ -101,7 +99,7 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     pub fn with_capacity(nodes: usize, root: N) -> (Self, NodeIndex<Ix>) {
         let mut graph = PetGraph::with_capacity(nodes, nodes);
         let root = graph.add_node(root);
-        (RoseTree { graph: graph }, root)
+        (RoseTree { graph }, root)
     }
 
     /// The total number of nodes in the RoseTree.
@@ -173,7 +171,6 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     ///
     /// Note: this method may shift other node indices, invalidating previously returned indices!
     pub fn remove_node(&mut self, node: NodeIndex<Ix>) -> Option<N> {
-
         // Check if an attempt to remove the root node has been made.
         if node.index() == ROOT || self.graph.node_weight(node).is_none() {
             return None;
@@ -210,7 +207,10 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     ///
     /// The returned iterator yields `NodeIndex<Ix>`s.
     pub fn parent_recursion(&self, child: NodeIndex<Ix>) -> ParentRecursion<N, Ix> {
-        ParentRecursion { rose_tree: self, child: child }
+        ParentRecursion {
+            rose_tree: self,
+            child,
+        }
     }
 
     /// An iterator over all nodes that are children to the node at the given index.
@@ -225,7 +225,7 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     /// Unlike the `Children` type, `WalkChildren` does not borrow the `RoseTree`.
     pub fn walk_children(&self, parent: NodeIndex<Ix>) -> WalkChildren<Ix> {
         let walk_edges = self.graph.walk_edges_directed(parent, pg::Outgoing);
-        WalkChildren { walk_edges: walk_edges }
+        WalkChildren { walk_edges }
     }
 
     /// An iterator over all nodes that are siblings to the node at the given index.
@@ -233,7 +233,10 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     /// The returned iterator yields `NodeIndex<Ix>`s.
     pub fn siblings(&self, child: NodeIndex<Ix>) -> Siblings<Ix> {
         let maybe_siblings = self.parent(child).map(|parent| self.children(parent));
-        Siblings { child: child, maybe_siblings: maybe_siblings }
+        Siblings {
+            child,
+            maybe_siblings,
+        }
     }
 
     /// A "walker" object that may be used to step through the siblings of the given child node.
@@ -241,65 +244,99 @@ impl<N, Ix> RoseTree<N, Ix> where Ix: IndexType {
     /// Unlike the `Siblings` type, `WalkSiblings` does not borrow the `RoseTree`.
     pub fn walk_siblings(&self, child: NodeIndex<Ix>) -> WalkSiblings<Ix> {
         let maybe_walk_children = self.parent(child).map(|parent| self.walk_children(parent));
-        WalkSiblings { child: child, maybe_walk_children: maybe_walk_children }
+        WalkSiblings {
+            child,
+            maybe_walk_children,
+        }
     }
-
 }
 
-
-impl<N, Ix> ::std::ops::Index<NodeIndex<Ix>> for RoseTree<N, Ix> where Ix: IndexType {
+impl<N, Ix> ::std::ops::Index<NodeIndex<Ix>> for RoseTree<N, Ix>
+where
+    Ix: IndexType,
+{
     type Output = N;
     fn index(&self, index: NodeIndex<Ix>) -> &N {
         &self.graph[index]
     }
 }
 
-impl<N, Ix> ::std::ops::IndexMut<NodeIndex<Ix>> for RoseTree<N, Ix> where Ix: IndexType {
+impl<N, Ix> ::std::ops::IndexMut<NodeIndex<Ix>> for RoseTree<N, Ix>
+where
+    Ix: IndexType,
+{
     fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut N {
         &mut self.graph[index]
     }
 }
 
-
-impl<'a, Ix> Iterator for Siblings<'a, Ix> where Ix: IndexType {
+impl<'a, Ix> Iterator for Siblings<'a, Ix>
+where
+    Ix: IndexType,
+{
     type Item = NodeIndex<Ix>;
     fn next(&mut self) -> Option<NodeIndex<Ix>> {
-        let Siblings { child, ref mut maybe_siblings } = *self;
+        let Siblings {
+            child,
+            ref mut maybe_siblings,
+        } = *self;
         maybe_siblings.as_mut().and_then(|siblings| {
             siblings.next().and_then(|sibling| {
-                if sibling != child { Some(sibling) } else { siblings.next() }
+                if sibling != child {
+                    Some(sibling)
+                } else {
+                    siblings.next()
+                }
             })
         })
     }
 }
 
-impl<'a, N, Ix> Iterator for ParentRecursion<'a, N, Ix> where Ix: IndexType {
+impl<'a, N, Ix> Iterator for ParentRecursion<'a, N, Ix>
+where
+    Ix: IndexType,
+{
     type Item = NodeIndex<Ix>;
     fn next(&mut self) -> Option<NodeIndex<Ix>> {
-        let ParentRecursion { ref mut child, ref rose_tree } = *self;
-        rose_tree.parent(*child).map(|parent| { *child = parent; parent })
+        let ParentRecursion {
+            ref mut child,
+            ref rose_tree,
+        } = *self;
+        rose_tree.parent(*child).map(|parent| {
+            *child = parent;
+            parent
+        })
     }
 }
 
-
-impl<Ix> WalkChildren<Ix> where Ix: IndexType {
+impl<Ix> WalkChildren<Ix>
+where
+    Ix: IndexType,
+{
     /// Fetch the next child index in the walk for the given `RoseTree`.
     pub fn next<N>(&mut self, tree: &RoseTree<N, Ix>) -> Option<NodeIndex<Ix>> {
         self.walk_edges.next_neighbor(&tree.graph).map(|(_, n)| n)
     }
 }
 
-impl<Ix> WalkSiblings<Ix> where Ix: IndexType {
+impl<Ix> WalkSiblings<Ix>
+where
+    Ix: IndexType,
+{
     /// Fetch the next sibling index in the walk for the given `RoseTree`.
     pub fn next<N>(&mut self, tree: &RoseTree<N, Ix>) -> Option<NodeIndex<Ix>> {
-        let WalkSiblings { child, ref mut maybe_walk_children } = *self;
+        let WalkSiblings {
+            child,
+            ref mut maybe_walk_children,
+        } = *self;
         maybe_walk_children.as_mut().and_then(|walk_children| {
-            walk_children.next(tree).and_then(|sibling| if child != sibling {
-                Some(sibling)
-            } else {
-                walk_children.next(tree)
+            walk_children.next(tree).and_then(|sibling| {
+                if child != sibling {
+                    Some(sibling)
+                } else {
+                    walk_children.next(tree)
+                }
             })
         })
     }
 }
-


### PR DESCRIPTION
Fixes #3 

The main aim of this PR is to update `petgraph` to its latest version so that `rose_tree` can be used with newer `rustc` versions with `std` updates.

I'll also note that I did some house cleaning while I was poking around, hope you don't mind :)

Here is a breakdown of the notable changes:
* `DefIndex` has been removed from `petgraph` so I decided to inline it here.
* `WalkEdges` has been removed. Working backwards I saw [`walk_edges_directed`](https://docs.rs/petgraph/0.2.0/petgraph/graph/struct.Graph.html#method.walk_edges_directed) was used and in the documentation it says it was deprecated and to use [`neighbors_directed`](https://docs.rs/petgraph/0.2.0/petgraph/graph/struct.Graph.html#method.neighbors_directed) followed by `detach()` instead. This means that `WalkEdges` becomes [`WalkNeighbors`](https://docs.rs/petgraph/0.2.0/petgraph/graph/struct.WalkNeighbors.html).
* `next_neighbor` calls become `next`.